### PR TITLE
Version bump for the Log forwarding lambda

### DIFF
--- a/cloudwatch-logs-s3-forwarder/variables.tf
+++ b/cloudwatch-logs-s3-forwarder/variables.tf
@@ -34,7 +34,7 @@ variable "lambda_s3_bucket" {
 }
 
 variable "s3_key" {
-  default     = "cloudwatch-logs-remote-bucket-1.1.zip"
+  default     = "cloudwatch-logs-remote-bucket-1.2.zip"
   description = "The s3 key for the Lambda artifact."
 }
 


### PR DESCRIPTION
TLDR; The lambda now uses Jackson for JSON serialization and deserialization instead of GSON. This object mapper respects the ```   @JsonUnwrapped``` annotation. This enables us to extend the logged event with new fields, instead of Wrapping the original document in an envelope.  

https://github.com/TeliaSoneraNorge/cloudwatch-subscriptions-s3-writer/commit/844cc87fe5a25fb6d6e8eeeba2024ed1f0e5e905

Lights are green; 
https://concourse.common-services.telia.io/teams/cloudops/pipelines/cloudwatch-s3-forwarder/jobs/compile-and-test/builds/41


