### PR TITLE
Elasticcache module moved from legacy repo

### DIFF
--- a/elasticcache/README.rd
+++ b/elasticcache/README.rd
@@ -1,0 +1,2 @@
+# ElastiCache
+

--- a/elasticcache/README.rd
+++ b/elasticcache/README.rd
@@ -1,2 +1,4 @@
 # ElastiCache
 
+Basic module for Elasticcache that will provision a Memcached cluster in subnets
+of your choosing. see variables.tf for defaults

--- a/elasticcache/example/default/main.tf
+++ b/elasticcache/example/default/main.tf
@@ -6,16 +6,9 @@ data "aws_subnet_ids" "main" {
   vpc_id = "${data.aws_vpc.main.id}"
 }
 
-resource "aws_security_group" "cache_sec_group" {
-  name        = "exammple_sg"
-  description = "Allow TLS inbound traffic"
-  vpc_id      = "${data.aws_vpc.main.id}"
-}
-
 module "example_elasticcache_cluster" {
-  source                   = "../.."
-  prefix                   = "example"
-  vpc_id                   = "${data.aws_vpc.main.id}"
-  subnet_ids               = "${data.aws_subnet_ids.main.ids}"
-  source_security_group_id = "${aws_security_group.cache_sec_group.id}"
+  source     = "../.."
+  prefix     = "example"
+  vpc_id     = "${data.aws_vpc.main.id}"
+  subnet_ids = "${data.aws_subnet_ids.main.ids}"
 }

--- a/elasticcache/example/default/main.tf
+++ b/elasticcache/example/default/main.tf
@@ -1,0 +1,21 @@
+data "aws_vpc" "main" {
+  default = true
+}
+
+data "aws_subnet_ids" "main" {
+  vpc_id = "${data.aws_vpc.main.id}"
+}
+
+resource "aws_security_group" "cache_sec_group" {
+  name        = "exammple_sg"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = "${data.aws_vpc.main.id}"
+}
+
+module "example_elasticcache_cluster" {
+  source                   = "../.."
+  prefix                   = "example"
+  vpc_id                   = "${data.aws_vpc.main.id}"
+  subnet_ids               = "${data.aws_subnet_ids.main.ids}"
+  source_security_group_id = "${aws_security_group.cache_sec_group.id}"
+}

--- a/elasticcache/main.tf
+++ b/elasticcache/main.tf
@@ -1,0 +1,39 @@
+# Documentation
+# https://www.terraform.io/docs/providers/aws/r/elasticache_cluster.html
+
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "main"
+  subnet_ids = ["${var.subnet_ids}"]
+}
+
+resource "aws_elasticache_cluster" "main" {
+  subnet_group_name    = "${aws_elasticache_subnet_group.main.name}"
+  security_group_ids   = ["${aws_security_group.main.id}"]
+  cluster_id           = "${var.prefix}"
+  parameter_group_name = "${var.parameter_group_name}"
+  engine               = "${var.engine}"
+  node_type            = "${var.node_type}"
+  num_cache_nodes      = "${var.num_cache_nodes}"
+  az_mode              = "${var.az_mode}"
+  port                 = "${var.port}"
+
+  tags = "${var.tags}"
+}
+
+resource "aws_security_group" "main" {
+  name        = "${var.prefix}-memcached-sg"
+  description = "Terraformed security group."
+  vpc_id      = "${var.vpc_id}"
+
+  tags = "${merge(var.tags, map("Name", "${var.prefix}-memcached-sg"))}"
+}
+
+resource "aws_security_group_rule" "ingress" {
+  description              = "Terraformed security group rule."
+  security_group_id        = "${aws_security_group.main.id}"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = "${var.port}"
+  to_port                  = "${var.port}"
+  source_security_group_id = "${var.source_security_group_id}"
+}

--- a/elasticcache/main.tf
+++ b/elasticcache/main.tf
@@ -27,13 +27,3 @@ resource "aws_security_group" "main" {
 
   tags = "${merge(var.tags, map("Name", "${var.prefix}-memcached-sg"))}"
 }
-
-resource "aws_security_group_rule" "ingress" {
-  description              = "Terraformed security group rule."
-  security_group_id        = "${aws_security_group.main.id}"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = "${var.port}"
-  to_port                  = "${var.port}"
-  source_security_group_id = "${var.source_security_group_id}"
-}

--- a/elasticcache/outputs.tf
+++ b/elasticcache/outputs.tf
@@ -1,0 +1,14 @@
+# Documentation
+# https://www.terraform.io/docs/providers/aws/r/elasticache_cluster.html
+
+output "cache_nodes" {
+  value = "${aws_elasticache_cluster.main.cache_nodes}"
+}
+
+output "configuration_endpoint" {
+  value = "${aws_elasticache_cluster.main.configuration_endpoint}"
+}
+
+output "cluster_address" {
+  value = "${aws_elasticache_cluster.main.cluster_address}"
+}

--- a/elasticcache/outputs.tf
+++ b/elasticcache/outputs.tf
@@ -12,3 +12,7 @@ output "configuration_endpoint" {
 output "cluster_address" {
   value = "${aws_elasticache_cluster.main.cluster_address}"
 }
+
+output "cache_security_group_id" {
+  value = "${aws_security_group.main.id}"
+}

--- a/elasticcache/variables.tf
+++ b/elasticcache/variables.tf
@@ -1,0 +1,50 @@
+# Documentation
+# https://www.terraform.io/docs/providers/aws/r/elasticache_cluster.html
+
+variable "prefix" {
+  description = "A prefix used for naming resources."
+  default     = "main"
+}
+
+variable "parameter_group_name" {
+  default = "default.memcached1.4"
+}
+
+variable "engine" {
+  default = "memcached"
+}
+
+variable "node_type" {
+  default = "cache.t2.micro"
+}
+
+variable "num_cache_nodes" {
+  default = 2
+}
+
+variable "az_mode" {
+  default = "cross-az"
+}
+
+variable "port" {
+  default = 11211
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC for the subnets."
+}
+
+variable "subnet_ids" {
+  description = "ID of subnets for the RDS subnet group."
+  type        = "list"
+}
+
+variable "source_security_group_id" {
+  description = "The security group id to allow access from."
+}
+
+variable "tags" {
+  description = "A map of tags (key-value pairs) passed to resources."
+  type        = "map"
+  default     = {}
+}

--- a/elasticcache/variables.tf
+++ b/elasticcache/variables.tf
@@ -7,7 +7,7 @@ variable "prefix" {
 }
 
 variable "parameter_group_name" {
-  default = "default.memcached1.4"
+  default = "default.memcached1.5"
 }
 
 variable "engine" {
@@ -35,7 +35,7 @@ variable "vpc_id" {
 }
 
 variable "subnet_ids" {
-  description = "ID of subnets for the RDS subnet group."
+  description = "ID of subnets for the elasticca subnet group."
   type        = "list"
 }
 


### PR DESCRIPTION
Elasticcache module moved from legacy repo (read only)

I removed the variable "source_security_group_id", and instead output the security group id of the memcached cluster so that clients of the module can add rules to themselves. This is a breaking change that I assume will be just fine since users will need to change module source to use this verison. 

