### PR TITLE
engine version and parameter group name with explicit values in defaults

### DIFF
--- a/elasticcache/outputs.tf
+++ b/elasticcache/outputs.tf
@@ -16,3 +16,7 @@ output "cluster_address" {
 output "cache_security_group_id" {
   value = "${aws_security_group.main.id}"
 }
+
+output "port" {
+  value = "${aws_elasticache_cluster.main.port}"
+}

--- a/elasticcache/variables.tf
+++ b/elasticcache/variables.tf
@@ -6,12 +6,17 @@ variable "prefix" {
   default     = "main"
 }
 
-variable "parameter_group_name" {
-  default = "default.memcached1.5"
-}
-
+# Engine, enginve_version and parameter_group_name must be coherent.
 variable "engine" {
   default = "memcached"
+}
+
+variable "engine_version" {
+  default = "1.15.10"
+}
+
+variable "parameter_group_name" {
+  default = "default.memcached1.5"
 }
 
 variable "node_type" {


### PR DESCRIPTION
Engine version was left empty be the default variables, picking the latest one.(now 1.5) The privacy hub project had a parameter group set for Version 1.4 leading to an error. We should set defaults for the engine, engine version and parameter group name that is coherent in the defaults. 

Also added the port to outputs, so that users of the module can get the port and use it as a reference in for example security group rules