### PR TITLE
change detector disabling mechanic to preserve finding history

### DIFF
--- a/multi-region-guardduty/regions.tf
+++ b/multi-region-guardduty/regions.tf
@@ -5,9 +5,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "us-east-1" {
-  count    = "${contains(var.regions, "us-east-1") ? 1 : 0}"
   provider = "aws.us-east-1"
-  enable   = true
+  enable   = contains(var.regions, "us-east-1")
 }
 
 # us-east-2 --------------------------------------------------------------------------
@@ -17,9 +16,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "us-east-2" {
-  count    = "${contains(var.regions, "us-east-2") ? 1 : 0}"
   provider = "aws.us-east-2"
-  enable   = true
+  enable   = contains(var.regions, "us-east-2")
 }
 
 # us-west-1 --------------------------------------------------------------------------
@@ -29,9 +27,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "us-west-1" {
-  count    = "${contains(var.regions, "us-west-1") ? 1 : 0}"
   provider = "aws.us-west-1"
-  enable   = true
+  enable   = contains(var.regions, "us-west-1")
 }
 
 # us-west-2 --------------------------------------------------------------------------
@@ -41,9 +38,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "us-west-2" {
-  count    = "${contains(var.regions, "us-west-2") ? 1 : 0}"
   provider = "aws.us-west-2"
-  enable   = true
+  enable   = contains(var.regions, "us-west-2")
 }
 
 # ca-central-1 --------------------------------------------------------------------------
@@ -53,9 +49,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "ca-central-1" {
-  count    = "${contains(var.regions, "ca-central-1") ? 1 : 0}"
   provider = "aws.ca-central-1"
-  enable   = true
+  enable   = contains(var.regions, "ca-central-1")
 }
 
 # eu-central-1 --------------------------------------------------------------------------
@@ -65,9 +60,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "eu-central-1" {
-  count    = "${contains(var.regions, "eu-central-1") ? 1 : 0}"
   provider = "aws.eu-central-1"
-  enable   = true
+  enable   = contains(var.regions, "eu-central-1")
 }
 
 # eu-west-1 --------------------------------------------------------------------------
@@ -77,9 +71,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "eu-west-1" {
-  count    = "${contains(var.regions, "eu-west-1") ? 1 : 0}"
   provider = "aws.eu-west-1"
-  enable   = true
+  enable   = contains(var.regions, "eu-west-1")
 }
 
 # eu-west-2 --------------------------------------------------------------------------
@@ -89,9 +82,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "eu-west-2" {
-  count    = "${contains(var.regions, "eu-west-2") ? 1 : 0}"
   provider = "aws.eu-west-2"
-  enable   = true
+  enable   = contains(var.regions, "eu-west-2")
 }
 
 # eu-west-3 --------------------------------------------------------------------------
@@ -101,9 +93,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "eu-west-3" {
-  count    = "${contains(var.regions, "eu-west-3") ? 1 : 0}"
   provider = "aws.eu-west-3"
-  enable   = true
+  enable   = contains(var.regions, "eu-west-3")
 }
 
 # ap-northeast-1 --------------------------------------------------------------------------
@@ -113,9 +104,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "ap-northeast-1" {
-  count    = "${contains(var.regions, "ap-northeast-1") ? 1 : 0}"
   provider = "aws.ap-northeast-1"
-  enable   = true
+  enable   = contains(var.regions, "ap-northeast-1")
 }
 
 # ap-northeast-2 --------------------------------------------------------------------------
@@ -125,9 +115,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "ap-northeast-2" {
-  count    = "${contains(var.regions, "ap-northeast-2") ? 1 : 0}"
   provider = "aws.ap-northeast-2"
-  enable   = true
+  enable   = contains(var.regions, "ap-northeast-2")
 }
 
 # ap-southeast-1 --------------------------------------------------------------------------
@@ -137,9 +126,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "ap-southeast-1" {
-  count    = "${contains(var.regions, "ap-southeast-1") ? 1 : 0}"
   provider = "aws.ap-southeast-1"
-  enable   = true
+  enable   = contains(var.regions, "ap-southeast-1")
 }
 
 # ap-southeast-2 --------------------------------------------------------------------------
@@ -149,9 +137,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "ap-southeast-2" {
-  count    = "${contains(var.regions, "ap-southeast-2") ? 1 : 0}"
   provider = "aws.ap-southeast-2"
-  enable   = true
+  enable   = contains(var.regions, "ap-southeast-2")
 }
 
 # ap-south-1 --------------------------------------------------------------------------
@@ -161,9 +148,8 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "ap-south-1" {
-  count    = "${contains(var.regions, "ap-south-1") ? 1 : 0}"
   provider = "aws.ap-south-1"
-  enable   = true
+  enable   = contains(var.regions, "ap-south-1")
 }
 
 # sa-east-1 --------------------------------------------------------------------------
@@ -173,7 +159,6 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "sa-east-1" {
-  count    = "${contains(var.regions, "sa-east-1") ? 1 : 0}"
   provider = "aws.sa-east-1"
-  enable   = true
+  enable   = contains(var.regions, "sa-east-1")
 }


### PR DESCRIPTION
the purpose of this PR is to change how the disable behavior for detectors so that instead of deleting the detector, 'enabled' is set to `false` instead. the reason for this is that the docs recommend disabling instead of deleting the detector because when a detector is deleted, its finding history is removed along with the detector itself. disabling will preserve finding history for if the detector comes back or if historical findings need to be referenced later on.